### PR TITLE
Feature/fix-status-map

### DIFF
--- a/status_map/__init__.py
+++ b/status_map/__init__.py
@@ -75,7 +75,7 @@ class StatusMap(Mapping):
     def __iter__(self):
         return iter(self._statuses)
 
-    def _add_status(self, status, previous=None, count=1):
+    def _add_status(self, status, previous=None):
         if status in self._statuses:
             return
 
@@ -89,8 +89,7 @@ class StatusMap(Mapping):
             current._add_next(self._transitions[current.name])
 
             if current.name not in self._statuses:
-                count += 1
-                self._add_status(current, status, count)
+                self._add_status(current, status)
 
     def validate_transition(self, from_status, to_status):
         if from_status not in self._statuses:

--- a/status_map/__init__.py
+++ b/status_map/__init__.py
@@ -2,7 +2,7 @@ from collections.abc import Mapping
 
 from .exceptions import RepeatedTransition, StatusNotFound, TransitionNotFound
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 
 class Status:

--- a/status_map/__init__.py
+++ b/status_map/__init__.py
@@ -8,8 +8,8 @@ __version__ = "0.1.0"
 class Status:
     def __init__(self, name, next=None):
         self.name = name
-        self.previous = set()
-        self.next = set()
+        self.previous = []
+        self.next = []
 
         if next:
             self._add_next(next)
@@ -42,19 +42,19 @@ class Status:
         if isinstance(other_status, (list, set, tuple)):
             return self._add_many("next", other_status)
 
-        self.next.add(other_status)
+        self.next.append(other_status)
 
     def _add_previous(self, previous):
         if isinstance(previous, (list, set, tuple)):
             return self._add_many("previous", previous)
 
-        self.previous.add(previous)
-        self.previous.update(previous.previous)
+        self.previous.append(previous)
+        self.previous.extend(previous.previous)
 
 
 class StatusMap(Mapping):
     def __init__(self, transitions):
-        self._transitions = dict(transitions or self.transitions)
+        self._transitions = dict(transitions)
         assert self._transitions, "must pass a non-empty dict"
 
         self._statuses = {}
@@ -75,7 +75,7 @@ class StatusMap(Mapping):
     def __iter__(self):
         return iter(self._statuses)
 
-    def _add_status(self, status, previous=None):
+    def _add_status(self, status, previous=None, count=1):
         if status in self._statuses:
             return
 
@@ -89,7 +89,8 @@ class StatusMap(Mapping):
             current._add_next(self._transitions[current.name])
 
             if current.name not in self._statuses:
-                self._add_status(current, status)
+                count += 1
+                self._add_status(current, status, count)
 
     def validate_transition(self, from_status, to_status):
         if from_status not in self._statuses:

--- a/tests/test_status_map.py
+++ b/tests/test_status_map.py
@@ -3,6 +3,7 @@ import pytest
 
 from status_map import __version__, Status, StatusMap
 from status_map.exceptions import RepeatedTransition, StatusNotFound, TransitionNotFound
+from .utils import assert_list
 
 
 @pytest.fixture
@@ -29,7 +30,7 @@ def test_status():
     status = Status("stat")
 
     assert status.name == "stat"
-    assert status.next == set()
+    assert status.next == []
 
 
 def test_status_magic_methods():
@@ -53,7 +54,7 @@ def test_status_add_next_str():
 
     status._add_next("other")
 
-    assert status.next == {"other"}
+    assert status.next == ["other"]
     for next_status in status.next:
         assert isinstance(next_status, Status)
 
@@ -61,9 +62,9 @@ def test_status_add_next_str():
 def test_status_add_next_set():
     status = Status("stat")
 
-    status._add_next({"other", "+1", "foo"})
+    status._add_next(["other", "+1", "foo"])
 
-    assert status.next == {"other", "+1", "foo"}
+    assert_list(status.next, ["other", "+1", "foo"])
     for next_status in status.next:
         assert isinstance(next_status, Status)
 
@@ -73,17 +74,17 @@ def test_status_add_previous_str():
 
     status._add_previous(Status("other"))
 
-    assert status.previous == {"other"}
+    assert status.previous == ["other"]
     for previous_status in status.previous:
         assert isinstance(previous_status, Status)
 
 
-def test_status_add_previous_set():
+def test_status_add_previous_list():
     status = Status("stat")
 
-    status._add_previous({Status("other"), Status("+1"), Status("foo")})
+    status._add_previous([Status("other"), Status("+1"), Status("foo")])
 
-    assert status.previous == {"other", "+1", "foo"}
+    assert_list(status.previous, ["other", "+1", "foo"])
     for previous_status in status.previous:
         assert isinstance(previous_status, Status)
 
@@ -102,29 +103,29 @@ def test_status_map_magic_methods(status_map):
     assert len(status_map) == 5
     assert iter(status_map)
     with pytest.raises(KeyError):
-        status_map["cu"]
+        status_map["does-not-exist"]
 
     # inherited
-    assert status_map.keys() == {"pending", "processing", "approved", "rejected", "processed"}
+    assert_list(status_map.keys(), ["pending", "processing", "approved", "rejected", "processed"])
     assert "pending" in status_map
-    assert "cu" not in status_map
+    assert "does-not-exist" not in status_map
     assert status_map.values()
     assert status_map.items()
     assert status_map.get("pending")
-    assert status_map.get("cu", None) is None
+    assert status_map.get("does-not-exist", None) is None
 
 
 def test_status_map_build_statuses(status_map):
-    assert status_map["pending"].next == {"processing"}
-    assert status_map["pending"].previous == set()
-    assert status_map["processing"].next == {"approved", "rejected"}
-    assert status_map["processing"].previous == {"pending"}
-    assert status_map["approved"].next == {"processed"}
-    assert status_map["approved"].previous == {"processing", "pending"}
-    assert status_map["rejected"].next == {"pending"}
-    assert status_map["rejected"].previous == {"processing", "pending"}
-    assert status_map["processed"].next == set()
-    assert status_map["processed"].previous == {"processing", "pending", "approved"}
+    assert_list(status_map["pending"].next, ["processing"])
+    assert_list(status_map["pending"].previous, [])
+    assert_list(status_map["processing"].next, ["approved", "rejected"])
+    assert_list(status_map["processing"].previous, ["pending"])
+    assert_list(status_map["approved"].next, ["processed"])
+    assert_list(status_map["approved"].previous, ["processing", "pending"])
+    assert_list(status_map["rejected"].next, ["pending"])
+    assert_list(status_map["rejected"].previous, ["processing", "pending"])
+    assert_list(status_map["processed"].next, [])
+    assert_list(status_map["processed"].previous, ["processing", "pending", "approved"])
 
 
 def test_validate_transition_accepeted_transitions(status_map):
@@ -140,17 +141,17 @@ def test_validate_transition_accepeted_transitions(status_map):
 
 def test_validate_transition_invalid_from_status(status_map):
     with pytest.raises(StatusNotFound) as exc:
-        status_map.validate_transition("cu", "processing")
+        status_map.validate_transition("does-not-exist", "processing")
 
-    assert "cu" in str(exc)
+    assert "does-not-exist" in str(exc)
     assert "from status" in str(exc)
 
 
 def test_validate_transition_invalid_to_status(status_map):
     with pytest.raises(StatusNotFound) as exc:
-        status_map.validate_transition("processing", "cu")
+        status_map.validate_transition("processing", "does-not-exist")
 
-    assert "cu" in str(exc)
+    assert "does-not-exist" in str(exc)
     assert "to status" in str(exc)
 
 
@@ -185,9 +186,8 @@ def test_validate_transition_transition_not_found(status_map):
         status_map.validate_transition("rejected", "processed")
 
 
-
-
-def test_simulate_random_mapping_error(): 
+@pytest.mark.repeat(10)
+def test_validate_status_should_work_in_correct_values_order():
     status_map = StatusMap({
         "": ("created", "sent"),
         "created": ("sent", "sent_error"),
@@ -197,20 +197,20 @@ def test_simulate_random_mapping_error():
         "published": ("rejected",),
     })
 
-    assert status_map[""].previous == set()
-    assert status_map[""].next == {"created", "sent"}
+    assert_list(status_map[""].previous, [])
+    assert_list(status_map[""].next, ["created", "sent"])
 
-    assert status_map["created"].previous == {""}
-    assert status_map["created"].next == {"sent", "sent_error"}
+    assert_list(status_map["created"].previous, [""])
+    assert_list(status_map["created"].next, ["sent", "sent_error"])
 
-    assert status_map["sent"].previous == {"", "created"}
-    assert status_map["sent"].next == {"published", "rejected"}
+    assert_list(status_map["sent"].previous, ["", "created"])
+    assert_list(status_map["sent"].next, ["published", "rejected"])
 
-    assert status_map["sent_error"].previous == {"", "created"}
-    assert status_map["sent_error"].next == {"created"}
+    assert_list(status_map["sent_error"].previous, ["", "created"])
+    assert_list(status_map["sent_error"].next, ["created"])
 
-    assert status_map["rejected"].previous == {"", "created", "sent"}
-    assert status_map["rejected"].next == {"sent"}
+    assert_list(status_map["rejected"].previous, ["", "created", "sent", "published"])
+    assert_list(status_map["rejected"].next, ["sent"])
 
-    assert status_map["published"].previous == {"", "created", "sent"}
-    assert status_map["published"].next == {"rejected"}
+    assert_list(status_map["published"].previous, ["", "created", "sent"])
+    assert_list(status_map["published"].next, ["rejected"])

--- a/tests/test_status_map.py
+++ b/tests/test_status_map.py
@@ -183,3 +183,34 @@ def test_validate_transition_transition_not_found(status_map):
 
     with pytest.raises(TransitionNotFound):
         status_map.validate_transition("rejected", "processed")
+
+
+
+
+def test_simulate_random_mapping_error(): 
+    status_map = StatusMap({
+        "": ("created", "sent"),
+        "created": ("sent", "sent_error"),
+        "sent": ("published", "rejected"),
+        "sent_error": ("created",),
+        "rejected": ("sent",),
+        "published": ("rejected",),
+    })
+
+    assert status_map[""].previous == set()
+    assert status_map[""].next == {"created", "sent"}
+
+    assert status_map["created"].previous == {""}
+    assert status_map["created"].next == {"sent", "sent_error"}
+
+    assert status_map["sent"].previous == {"", "created"}
+    assert status_map["sent"].next == {"published", "rejected"}
+
+    assert status_map["sent_error"].previous == {"", "created"}
+    assert status_map["sent_error"].next == {"created"}
+
+    assert status_map["rejected"].previous == {"", "created", "sent"}
+    assert status_map["rejected"].next == {"sent"}
+
+    assert status_map["published"].previous == {"", "created", "sent"}
+    assert status_map["published"].next == {"rejected"}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,4 @@
+def assert_list(first, second):
+    assert len(first) == len(second)
+    assert (set(first) - set(second)) == set()
+    assert (set(second) - set(first)) == set()


### PR DESCRIPTION
This PR, fix the [issue](https://github.com/lamenezes/status-map/issues/1), basically, I did a refactor on `Status` object, changing `previous` and `next` attributes type from `set` to `list` to ensure the correct order when the values of a `status` is processed.

I've added a new test with the scenario when the bug occur, before this PR this test failed and pass randomly, after this PR, this test always pass.